### PR TITLE
Add test cases for encoding/decoding a state vector

### DIFF
--- a/tests/test_state_vector.py
+++ b/tests/test_state_vector.py
@@ -71,11 +71,6 @@ def test_state_vector_set():
 
 
 def test_state_vector_decode():
-    """
-    Test if the TLVs complient with the NDN-SVS spec can be parsed and interprete
-    correctly
-    :return:
-    """
     enc_sv = b'\xCA\x03\x6F\x6E\x65\xCB\x01\x01\xCA\x03\x74\x77\x6F\xCB\x01\x02'
     enc_sv = Component.from_bytes(enc_sv, StateVectorModelTypes.VECTOR.value)
 
@@ -85,10 +80,6 @@ def test_state_vector_decode():
 
 
 def test_state_vector_encode():
-    """
-    Test if the TLV encoding of the state vector is complient with the NDN-SVS Spec
-    :return:
-    """
     sv = StateVector()
     sv.set("one", 1)
     sv.set("two", 2)

--- a/tests/test_state_vector.py
+++ b/tests/test_state_vector.py
@@ -13,7 +13,7 @@ import pytest
 from ndn.encoding import Component, Name
 # Custom Imports
 sys.path.insert(0,'.')
-from src.ndn.svs.state_vector import StateVector
+from src.ndn.svs.state_vector import StateVector, StateVectorModelTypes
 
 def test_state_vector_ordering():
     sv1 = StateVector()
@@ -69,17 +69,32 @@ def test_state_vector_set():
 
     assert sv.get("a") == 100
 
-def test_state_vector_decode():
-    sv = StateVector()
-    sv.set("one", 1)
-    sv.set("two", 2)
 
+def test_state_vector_decode():
+    """
+    Test if the TLVs complient with the NDN-SVS spec can be parsed and interprete
+    correctly
+    :return:
+    """
     enc_sv = b'\xCA\x03\x6F\x6E\x65\xCB\x01\x01\xCA\x03\x74\x77\x6F\xCB\x01\x02'
-    enc_sv = Component.from_bytes(enc_sv, 201)
+    enc_sv = Component.from_bytes(enc_sv, StateVectorModelTypes.VECTOR.value)
 
     sv = StateVector(enc_sv)
     assert sv.get("one") == 1
     assert sv.get("two") == 2
+
+
+def test_state_vector_encode():
+    """
+    Test if the TLV encoding of the state vector is complient with the NDN-SVS Spec
+    :return:
+    """
+    sv = StateVector()
+    sv.set("one", 1)
+    sv.set("two", 2)
+
+    enc_sv = sv.encode()
+    assert enc_sv == b'\xC9\x10\xCA\x03\x6F\x6E\x65\xCB\x01\x01\xCA\x03\x74\x77\x6F\xCB\x01\x02'
 
 def test_state_vector_component_functionality():
     sv = StateVector()


### PR DESCRIPTION
Hi @justincpresley,
in your test case, you had some StateVector generation before actually parsing the TLV. I did not see a reason for that. I removed that and added a test case to check if generated TLVs also comply with the standard.